### PR TITLE
Python > 3.9 compatibility

### DIFF
--- a/suite2p/detection/stats.py
+++ b/suite2p/detection/stats.py
@@ -56,7 +56,7 @@ class ROI:
     lam: np.ndarray
     med: np.ndarray
     do_crop: bool
-    rsort: np.ndarray = field(default=np.sort(distance_kernel(radius=30).flatten()),
+    rsort: np.ndarray = field(default_factory=lambda: np.sort(distance_kernel(radius=30).flatten()),
                               repr=False)
 
     def __post_init__(self):

--- a/suite2p/io/tiff.py
+++ b/suite2p/io/tiff.py
@@ -318,7 +318,7 @@ def mesoscan_to_binary(ops):
     nchannels = ops1[0]["nchannels"]
     batch_size = ops["batch_size"]
 
-    # which tiff reader works for user"s tiffs
+    # which tiff reader works for user's tiffs
     use_sktiff = True if ops["force_sktiff"] else use_sktiff_reader(
         fs[0], batch_size=ops1[0].get("batch_size"))
 


### PR DESCRIPTION
This commit by Simon Ball allows suite2p to run on later versions of Python. Marius won't merge this until 3.9 is end-of-life so I've cherry-picked from Simon's fork.  It has been tested by others and apparently works on at lease 3.9 - 3.12.  When I get the chance I'll test it myself locally but for now I'm creating the PR.